### PR TITLE
Update: netstat availability error message

### DIFF
--- a/bash_script/bash_task
+++ b/bash_script/bash_task
@@ -8,7 +8,7 @@ if [ -z $(which whois) ]; then
 fi
 
 if [ -z $(which netstat) ];then
-	echo "Tool 'netstat' not found. Please, install 'netstat'"
+	echo "Tool 'netstat' not found. Please, install 'net-tools' package"
 	exit 66 ### 'netstat' not found
 fi
 


### PR DESCRIPTION
Small change in the description of the netstat tool availability error.

The "netstat" tool is part of the "net-tools" package.